### PR TITLE
Fixed availability card on Professional Profile page to display time correctly

### DIFF
--- a/frontend/src/components/profProfile/Availability.tsx
+++ b/frontend/src/components/profProfile/Availability.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, {useEffect,useState} from 'react';
 import AvailabilityCard from './AvailabilityCard';
+import { fetchAvailability } from '../../../firebase/fetchData';
+import { IAvailability } from '@/schema';
+
 
 interface AvailabilityProps {
     availability: string[];
@@ -7,20 +10,54 @@ interface AvailabilityProps {
 
 const Availability = ({ availability = [] }: AvailabilityProps) => {
     const days = ['Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat', 'Sun'];
-
+    const [availabilities, setAvailabilities] = useState<IAvailability[]>([]);
+    
     // Calculate the maximum number of time slots among all days
     const maxTimeSlots = availability.reduce((max, times) => {
         const timeList = times.split(',').map(time => time.trim());
         return Math.max(max, timeList.length);
     }, 0);
 
+    // Fetch Data of this Availability based on availId 
+    const fetchAvailabilityInfo = async (availId) =>{
+        try{
+            const availData = await fetchAvailability(availId);//dgkPWTpDh87X1q18Pa6E
+            return availData;
+        } catch (error) {
+            console.error("Error fetching data with availId", availId);
+            return undefined;
+        }
+    }
+    useEffect(()=>{
+        // Update state of 'availabilites' with Data of this Availability
+        const fetchDataAvailIds = async () => {
+            const results = await Promise.all(availability.map((availId) => fetchAvailabilityInfo(availId)));
+            const validAvailabilities = results.filter(result => result != null) as IAvailability[];
+            console.log("valid Availabilities" , validAvailabilities);
+            setAvailabilities(validAvailabilities);
+        }
+        fetchDataAvailIds();
+        
+    },[availability]);
+
     return (
         <div className="h-fit">
             <div className={`grid grid-cols-7 gap-8`}>
                 {days.map((day, index) => {
-                    const times = availability[index] || ''; // Ensure times are available or an empty string
-                    const timeList = times.split(',').map(time => time.trim());
-                    const hasTimes = timeList.length > 0;
+                    console.log(index);
+                    // const availField = availability[index] || ''; // Ensure times are available or an empty string
+                    // const timeList = times.split(',').map(time => time.trim());
+                    // const hasTimes = availField.length > 0;
+                    console.log("state of availabilities " , availabilities);
+                    const start = availabilities[index]?.startTime.toDate()
+                    const end = availabilities[index]?.endTime.toDate()
+                    var times = ''
+                    
+                    // check if this availability exists
+                    if (availabilities[index]){
+                        times = `${start.getHours()}:${(start.getMinutes() < 10 ? '0' : '') + start.getMinutes()}-${end.getHours()}:${(end.getMinutes() < 10 ? '0' : '') + end.getMinutes()}` || ''
+                    }
+                    const hasTimes = times.length > 0;
 
                     return (
                         <AvailabilityCard


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

## Overview

Fixed display of Availability Card on Professional Profile page to show the time instead of the availId pertaining to a record in the "availabilities" collection

## Replication

`cd frontend`
`yarn dev`
Navigate to "Discover Professionals" and select a professional

## Changes Made

`Availability.tsx`: fetch Availability data from the Firebase collection and grab relevant data from each record, update state of 'availabilities' with this fetched data

## Test Coverage

Checked to see if time was displayed in HH:MM format on the Professional Profile Availability section 

## Related PRs or Issues

#95 

## Screenshots
<img width="1402" alt="Screen Shot 2023-12-02 at 8 23 33 PM" src="https://github.com/cornellh4i/okb-hope/assets/123703741/2fdec231-b33c-4b95-8128-20d97dd8e112">
<img width="1042" alt="Screen Shot 2023-12-02 at 8 23 41 PM" src="https://github.com/cornellh4i/okb-hope/assets/123703741/ff8b011b-d938-4fa8-8adf-220f97a8ae87">


<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot Name</summary>

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

</details>
