### PR TITLE
adding functionality to firebase that initiliazes all psychiastrists …

### DIFF
--- a/frontend/firebase/firebase.tsx
+++ b/frontend/firebase/firebase.tsx
@@ -102,6 +102,7 @@ const signUpWithGoogle = async (
             weeklyAvailability: weeklyAvailability,
             workingHours: workingHours,
             specialty: specialty,
+            status: "pending"
           });
           console.log("Added psych")
         }


### PR DESCRIPTION
Psychiatrists initialization

## Overview

Adding functionality to firebase that initiliazes all psychiastrists as pending in the db

## Replication

They can first make a psychiatrist account on the website then go to Firebase Console to look at the database to confirm status field set as pending.

## Changes Made

Initialized a new field, named status, in the psychiatrist database and set it as a string "pending".

## Test Coverage

Manual testing - as described in Replication.

## Screenshots

<img width="395" alt="Screenshot 2024-10-16 at 5 24 26 PM" src="https://github.com/user-attachments/assets/d1164144-9be4-4f9a-b726-d22bf2e07215">
